### PR TITLE
feat: add PR Opener Bot workflow

### DIFF
--- a/.github/workflows/create-pr-via-app.yml
+++ b/.github/workflows/create-pr-via-app.yml
@@ -1,0 +1,209 @@
+name: Create PR via GitHub App
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Source branch to open the pull request from
+        required: true
+        type: string
+      base:
+        description: Base branch to merge into
+        required: true
+        default: main
+        type: string
+      title:
+        description: Pull request title
+        required: true
+        type: string
+      body:
+        description: Pull request body in Markdown
+        required: false
+        default: ""
+        type: string
+      draft:
+        description: Open the pull request as a draft
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  create-pr:
+    name: Open pull request with PR Opener Bot
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate required secrets
+        shell: bash
+        env:
+          PR_APP_ID: ${{ secrets.PR_APP_ID }}
+          PR_APP_PRIVATE_KEY: ${{ secrets.PR_APP_PRIVATE_KEY }}
+        run: |
+          if [[ -z "$PR_APP_ID" ]]; then
+            echo "::error::Missing repository secret PR_APP_ID."
+            exit 1
+          fi
+
+          if [[ -z "$PR_APP_PRIVATE_KEY" ]]; then
+            echo "::error::Missing repository secret PR_APP_PRIVATE_KEY."
+            exit 1
+          fi
+
+      - name: Create PR Opener Bot installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.PR_APP_ID }}
+          private-key: ${{ secrets.PR_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Validate inputs and branch state
+        id: validate
+        uses: actions/github-script@v7
+        env:
+          INPUT_BRANCH: ${{ github.event.inputs.branch }}
+          INPUT_BASE: ${{ github.event.inputs.base }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = process.env.INPUT_BRANCH?.trim();
+            const base = process.env.INPUT_BASE?.trim();
+
+            if (!branch) {
+              core.setFailed("Input 'branch' is required.");
+              return;
+            }
+
+            if (!base) {
+              core.setFailed("Input 'base' is required.");
+              return;
+            }
+
+            if (branch === base) {
+              core.setFailed("The source branch and base branch must be different.");
+              return;
+            }
+
+            const ensureBranchExists = async (name, label) => {
+              try {
+                await github.rest.repos.getBranch({
+                  owner,
+                  repo,
+                  branch: name,
+                });
+              } catch (error) {
+                if (error.status === 404) {
+                  core.setFailed(`${label} branch '${name}' was not found in ${owner}/${repo}.`);
+                  return false;
+                }
+
+                throw error;
+              }
+
+              return true;
+            };
+
+            const sourceExists = await ensureBranchExists(branch, "Source");
+            if (!sourceExists) {
+              return;
+            }
+
+            const baseExists = await ensureBranchExists(base, "Base");
+            if (!baseExists) {
+              return;
+            }
+
+            const existingPulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              head: `${owner}:${branch}`,
+              base,
+              per_page: 100,
+            });
+
+            if (existingPulls.length > 0) {
+              const existing = existingPulls[0];
+              core.setFailed(
+                `An open pull request already exists for ${owner}:${branch} -> ${base}: ${existing.html_url}`
+              );
+              return;
+            }
+
+            core.setOutput("branch", branch);
+            core.setOutput("base", base);
+
+      - name: Create pull request and request review
+        id: create-pr
+        uses: actions/github-script@v7
+        env:
+          INPUT_TITLE: ${{ github.event.inputs.title }}
+          INPUT_BODY: ${{ github.event.inputs.body }}
+          INPUT_DRAFT: ${{ github.event.inputs.draft }}
+          SOURCE_BRANCH: ${{ steps.validate.outputs.branch }}
+          BASE_BRANCH: ${{ steps.validate.outputs.base }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = process.env.INPUT_TITLE?.trim();
+            const body = process.env.INPUT_BODY ?? "";
+            const draft = process.env.INPUT_DRAFT === "true";
+            const head = process.env.SOURCE_BRANCH;
+            const base = process.env.BASE_BRANCH;
+
+            if (!title) {
+              core.setFailed("Input 'title' is required.");
+              return;
+            }
+
+            const { data: pullRequest } = await github.rest.pulls.create({
+              owner,
+              repo,
+              title,
+              head,
+              base,
+              body,
+              draft,
+            });
+
+            core.info(`Created pull request #${pullRequest.number}: ${pullRequest.html_url}`);
+
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number: pullRequest.number,
+                reviewers: ["teohsinyee"],
+              });
+            } catch (error) {
+              core.setFailed(
+                `Pull request ${pullRequest.html_url} was created, but requesting review from teohsinyee failed: ${error.message}`
+              );
+              return;
+            }
+
+            core.setOutput("pr-number", String(pullRequest.number));
+            core.setOutput("pr-url", pullRequest.html_url);
+
+      - name: Write workflow summary
+        if: success()
+        shell: bash
+        env:
+          PR_URL: ${{ steps.create-pr.outputs.pr-url }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pr-number }}
+        run: |
+          {
+            echo "## PR Opener Bot result"
+            echo
+            echo "- Pull request: #${PR_NUMBER}"
+            echo "- URL: ${PR_URL}"
+            echo "- Reviewer requested: teohsinyee"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/changes/2026-06-06-github-app-pr-automation.decision.md
+++ b/docs/changes/2026-06-06-github-app-pr-automation.decision.md
@@ -1,0 +1,53 @@
+# Decision: GitHub App PR Automation
+
+## Decision Summary
+
+We will manage this work as a structured change record under `docs/changes` instead of keeping the plan only as a standalone root-level note.
+
+We will implement PR creation through a manually triggered GitHub Actions workflow that authenticates as a GitHub App installation.
+
+The GitHub App will be named `PR Opener Bot` so it can be reused across personal and work repos instead of sounding repo-specific.
+
+## Final Choices
+
+- Keep local development in Codex
+- Keep human intent explicit with `workflow_dispatch`
+- Use the GitHub App `PR Opener Bot` and its installation token to create pull requests
+- Request review from `teohsinyee` automatically
+- Start with minimum practical GitHub App permissions and widen only when implementation proves it is necessary
+
+## Why This Approach
+
+- `workflow_dispatch` is a clean governance checkpoint
+- A GitHub App gives clearer identity separation than using a personal token
+- A reusable bot identity solves the solo developer problem where the same personal account should not be both PR opener and approver
+- Installation-scoped auth is easier to reason about than a shared user account
+- Splitting planning into PRD, decision, spec, and logs makes future updates easier to extend without rewriting the original thinking
+
+## Tradeoffs
+
+### Benefits
+
+- Better audit trail
+- Narrower access surface
+- Clearer operator flow
+- Easier future maintenance
+
+### Costs
+
+- More setup than using a PAT
+- GitHub App permissions can be finicky in practice
+- Review requests or labels may require permission adjustments during implementation
+
+## Constraints
+
+- Human approval must stay required before merge
+- The GitHub App should not become a generic write path
+- Misconfiguration should fail clearly
+- The workflow should stay usable by a human operator without custom local tooling
+
+## Open Questions To Resolve During Implementation
+
+- Whether review requests need any extra permission beyond pull request write access
+- Whether duplicate PR prevention should be a hard block or a warning
+- Whether labels, assignees, or milestone support belong in the first implementation or later

--- a/docs/changes/2026-06-06-github-app-pr-automation.logs.md
+++ b/docs/changes/2026-06-06-github-app-pr-automation.logs.md
@@ -27,6 +27,20 @@ No live GitHub Actions run has been executed yet in this repo.
 - Result: Workflow file created locally; live validation still pending because repo secrets and GitHub App installation were not exercised in this session
 - Follow-up: Run the workflow in GitHub after configuring `PR_APP_ID` and `PR_APP_PRIVATE_KEY`, then record any permission or review-request surprises
 
+### 2026-06-06
+
+- Context: Needed a public-facing guide for getting `PR_APP_ID` and `PR_APP_PRIVATE_KEY`
+- Action: Added `docs/github-app-pr/app-credentials-guide.md` with step-by-step guidance for creating or opening a GitHub App, copying the App ID, generating a PEM private key, storing both as Actions secrets, and avoiding common mistakes
+- Result: The setup docs now include a dedicated credential guide that can be reused across repos and by non-expert operators
+- Follow-up: Keep the guide aligned if the workflow later moves `PR_APP_ID` from a secret to an Actions variable
+
+### 2026-06-06
+
+- Context: Wanted a local workflow lint check before asking for a live GitHub Actions run
+- Action: Installed `actionlint` version `1.7.12` via `winget`, then ran it against `.github/workflows/create-pr-via-app.yml`
+- Result: Lint passed with no workflow errors; on Windows, the new PATH entry was not available in the current shell immediately, so the installed binary was invoked via its absolute path under `AppData\\Local\\Microsoft\\WinGet\\Packages`
+- Follow-up: After opening a fresh shell, confirm whether the `actionlint` alias is available directly without the absolute path workaround
+
 ## Suggested Log Format
 
 ### YYYY-MM-DD

--- a/docs/changes/2026-06-06-github-app-pr-automation.logs.md
+++ b/docs/changes/2026-06-06-github-app-pr-automation.logs.md
@@ -36,6 +36,13 @@ No live GitHub Actions run has been executed yet in this repo.
 
 ### 2026-06-06
 
+- Context: The chat included important Create App form guidance that should not stay only in conversation history
+- Action: Expanded `docs/github-app-pr/app-credentials-guide.md` with recommended values and rationale for the Create GitHub App form, including homepage URL, callback URL, OAuth settings, webhook settings, repository permissions, organization permissions, and installation scope
+- Result: The docs now capture the practical field-by-field setup guidance needed during GitHub App creation
+- Follow-up: If the final chosen app name or permission set changes during live setup, update the guide to match the real production configuration
+
+### 2026-06-06
+
 - Context: Wanted a local workflow lint check before asking for a live GitHub Actions run
 - Action: Installed `actionlint` version `1.7.12` via `winget`, then ran it against `.github/workflows/create-pr-via-app.yml`
 - Result: Lint passed with no workflow errors; on Windows, the new PATH entry was not available in the current shell immediately, so the installed binary was invoked via its absolute path under `AppData\\Local\\Microsoft\\WinGet\\Packages`

--- a/docs/changes/2026-06-06-github-app-pr-automation.logs.md
+++ b/docs/changes/2026-06-06-github-app-pr-automation.logs.md
@@ -14,7 +14,18 @@ Use this file to capture implementation-time evidence that is worth preserving, 
 
 Planning structure created on `2026-06-06`.
 
-No implementation logs recorded yet.
+Workflow implementation added at `.github/workflows/create-pr-via-app.yml`.
+
+No live GitHub Actions run has been executed yet in this repo.
+
+## Recorded Notes
+
+### 2026-06-06
+
+- Context: First implementation pass for `PR Opener Bot` workflow
+- Action: Added a manual `workflow_dispatch` workflow that validates inputs, creates a GitHub App installation token, blocks duplicate open PRs, creates the PR, and requests review from `teohsinyee`
+- Result: Workflow file created locally; live validation still pending because repo secrets and GitHub App installation were not exercised in this session
+- Follow-up: Run the workflow in GitHub after configuring `PR_APP_ID` and `PR_APP_PRIVATE_KEY`, then record any permission or review-request surprises
 
 ## Suggested Log Format
 

--- a/docs/changes/2026-06-06-github-app-pr-automation.logs.md
+++ b/docs/changes/2026-06-06-github-app-pr-automation.logs.md
@@ -1,0 +1,26 @@
+# Logs: GitHub App PR Automation
+
+## Purpose
+
+Use this file to capture implementation-time evidence that is worth preserving, especially:
+
+- permission errors
+- token generation failures
+- review request edge cases
+- duplicate PR behavior
+- final validation results
+
+## Current Status
+
+Planning structure created on `2026-06-06`.
+
+No implementation logs recorded yet.
+
+## Suggested Log Format
+
+### YYYY-MM-DD
+
+- Context:
+- Action:
+- Result:
+- Follow-up:

--- a/docs/changes/2026-06-06-github-app-pr-automation.prd.md
+++ b/docs/changes/2026-06-06-github-app-pr-automation.prd.md
@@ -1,0 +1,62 @@
+# PRD: GitHub App PR Automation
+
+## Problem
+
+We want AI-assisted local development to stay fast, but we do not want pull requests to be opened under the human approver identity by default.
+
+This is especially painful for a solo developer workflow. When AI helps write code, the same human still needs a workable review and merge path. If the PR is opened under the same personal account that is supposed to review it, that person cannot meaningfully separate PR opening from PR approval.
+
+## Goal
+
+Create a governed pull request creation path where:
+
+- Codex can work locally and create commits with author `Codex <codex@openai.com>`
+- A human explicitly decides when a pull request should be opened
+- The pull request is created through the GitHub App identity `PR Opener Bot`
+- Human review remains required before merge
+
+## Why This Matters
+
+- It separates AI-authored development from human approval
+- It separates PR opening from PR approval for solo developers
+- It improves auditability compared with using a personal account end to end
+- It gives us a narrower permission model than a shared bot user
+- It creates a repeatable workflow that can scale beyond one repo or one session
+- It creates one reusable bot identity for both personal and work repos
+
+## Users
+
+- Primary operator: the human maintainer who triggers pull request creation
+- Secondary operator: Codex working locally on implementation changes
+- Reviewer: `teohsinyee`
+- GitHub App identity: `PR Opener Bot`
+
+## Success Criteria
+
+- Codex-authored commits can still be pushed normally
+- A human can trigger pull request creation manually
+- The PR is opened through the GitHub App path, not the reviewer personal identity
+- Review is automatically requested from `teohsinyee`
+- The workflow is documented clearly enough to repeat later without relying on memory
+- The same GitHub App pattern can be reused across multiple repos
+
+## Non-Goals
+
+- Replacing human review
+- Auto-merging AI-generated changes
+- Letting the GitHub App approve pull requests
+- Expanding the GitHub App into a broad repo admin identity
+
+## Deliverables
+
+- A GitHub App configuration checklist
+- A GitHub Actions workflow for manual PR creation
+- Repo documentation for the operator flow
+- Validation notes capturing any GitHub permission or API surprises
+
+## Documentation Targets
+
+To keep planning and execution cleanly separated:
+
+- change intent lives under `docs/changes/`
+- operator runbooks live under `docs/github-app-pr/`

--- a/docs/changes/2026-06-06-github-app-pr-automation.spec.md
+++ b/docs/changes/2026-06-06-github-app-pr-automation.spec.md
@@ -1,0 +1,131 @@
+# Spec: GitHub App PR Automation
+
+## Scope
+
+This spec defines the first implementation of GitHub App based pull request creation for this repo.
+
+## Workflow
+
+1. Codex works locally and creates commits with author `Codex <codex@openai.com>`.
+2. A human pushes the branch normally.
+3. A human manually triggers a GitHub Actions workflow with `workflow_dispatch`.
+4. The workflow validates the requested branch and base branch inputs.
+5. The workflow generates a `PR Opener Bot` GitHub App installation token.
+6. The workflow creates a pull request from the requested branch to the requested base.
+7. The workflow requests review from `teohsinyee`.
+8. `teohsinyee` reviews and decides whether to merge.
+
+## Identity Goal
+
+This flow exists to separate PR opening from PR approval in AI-assisted solo developer workflows.
+
+The PR should be opened by `PR Opener Bot`, while the human maintainer keeps the reviewer or approver role under their personal account.
+
+## Required Inputs
+
+The first version should support:
+
+- `branch`
+- `base`
+- `title`
+- `body`
+- `draft`
+
+Possible later additions:
+
+- `labels`
+- `milestone`
+- `assignees`
+
+## Required GitHub App Permissions
+
+Start with:
+
+- `Contents: Read and write`
+- `Pull requests: Read and write`
+- `Metadata: Read`
+
+Only add more scopes after confirming a concrete API requirement.
+
+## Required Repository Secrets
+
+- `PR_APP_ID`
+- `PR_APP_PRIVATE_KEY`
+
+Optional if implementation requires it:
+
+- `PR_APP_INSTALLATION_ID`
+
+## Required Workflow Behavior
+
+The workflow must:
+
+- accept manual dispatch inputs
+- validate that the source branch exists on the remote
+- fail clearly when configuration is missing or invalid
+- create the PR using the `PR Opener Bot` installation token
+- support draft PR creation
+- request review from `teohsinyee`
+
+The workflow should, when practical:
+
+- detect duplicate open PRs for the same branch
+- return a clear operator-facing error message when the PR already exists
+
+## Phases
+
+### Phase 1: Identity and Permissions
+
+- Create the GitHub App
+- Install it on the target repo
+- Confirm the App can authenticate inside GitHub Actions
+- Confirm repo metadata access works
+
+Exit criteria:
+
+- A workflow can obtain a valid GitHub App installation token
+
+### Phase 2: Minimal PR Creation
+
+- Create the manual `workflow_dispatch` workflow
+- Accept `branch`, `base`, and `title`
+- Create a draft PR through the App identity
+
+Exit criteria:
+
+- A manual run opens a PR as the GitHub App, not the reviewer personal identity
+
+### Phase 3: Review Routing
+
+- Add `body` and `draft`
+- Request review from `teohsinyee`
+- Improve failure messages for common operator mistakes
+
+Exit criteria:
+
+- The workflow opens the PR and requests human review automatically
+
+### Phase 4: Governance Hardening
+
+- Add branch existence checks
+- Add duplicate PR protection when practical
+- Document the operator workflow in the repo
+
+Exit criteria:
+
+- The flow is safe enough for repeated use
+
+## Validation Order
+
+1. Verify App installation and permissions
+2. Verify token creation in Actions
+3. Verify draft PR creation from a test branch
+4. Verify review request to `teohsinyee`
+5. Verify `teohsinyee` can still approve the PR
+
+## Supporting Documentation
+
+The following operator-facing docs should exist and stay aligned with the workflow implementation:
+
+- `docs/github-app-pr/setup-checklist.md`
+- `docs/github-app-pr/operator-guide.md`

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -1,0 +1,32 @@
+# Change Index
+
+This folder records why a change exists, not only what changed.
+
+It is here so future implementation work does not have to rediscover the same intent, tradeoffs, and operating rules from scratch.
+
+Use:
+
+- `*.prd.md` for the goal, context, and why the change matters
+- `*.decision.md` for tradeoffs, constraints, and final choices
+- `*.spec.md` for the implementation and operating rules
+- `*.logs.md` for failures, lessons, and validation notes worth keeping
+
+## Naming Convention
+
+Use date-prefixed filenames so changes sort naturally:
+
+```text
+YYYY-MM-DD-change-name.prd.md
+YYYY-MM-DD-change-name.decision.md
+YYYY-MM-DD-change-name.spec.md
+YYYY-MM-DD-change-name.logs.md
+```
+
+## Current Changes
+
+- `2026-06-06-github-app-pr-automation`
+  - PRD: [2026-06-06-github-app-pr-automation.prd.md](./2026-06-06-github-app-pr-automation.prd.md)
+  - Decision: [2026-06-06-github-app-pr-automation.decision.md](./2026-06-06-github-app-pr-automation.decision.md)
+  - Spec: [2026-06-06-github-app-pr-automation.spec.md](./2026-06-06-github-app-pr-automation.spec.md)
+  - Logs: [2026-06-06-github-app-pr-automation.logs.md](./2026-06-06-github-app-pr-automation.logs.md)
+  - Supporting docs: [operator guide](../github-app-pr/operator-guide.md), [setup checklist](../github-app-pr/setup-checklist.md)

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -29,4 +29,4 @@ YYYY-MM-DD-change-name.logs.md
   - Decision: [2026-06-06-github-app-pr-automation.decision.md](./2026-06-06-github-app-pr-automation.decision.md)
   - Spec: [2026-06-06-github-app-pr-automation.spec.md](./2026-06-06-github-app-pr-automation.spec.md)
   - Logs: [2026-06-06-github-app-pr-automation.logs.md](./2026-06-06-github-app-pr-automation.logs.md)
-  - Supporting docs: [operator guide](../github-app-pr/operator-guide.md), [setup checklist](../github-app-pr/setup-checklist.md)
+  - Supporting docs: [operator guide](../github-app-pr/operator-guide.md), [setup checklist](../github-app-pr/setup-checklist.md), [app credentials guide](../github-app-pr/app-credentials-guide.md)

--- a/docs/github-app-pr/app-credentials-guide.md
+++ b/docs/github-app-pr/app-credentials-guide.md
@@ -55,6 +55,89 @@ Recommended purpose:
 
 - `Open pull requests for AI-assisted repo work so the human maintainer can stay in the review and approval path`
 
+## Recommended Create App Form Values
+
+Use the smallest practical setup for this workflow.
+
+### Basic Information
+
+- `GitHub App name`: use your chosen unique app name, for example `AI PR Opener Bot`
+- Description: `Open pull requests for AI-assisted repo work so the human maintainer can stay in the review and approval path`
+- `Homepage URL`: use a repository URL that explains or hosts the workflow, such as `https://github.com/teohsinyee/engineering-lab`
+
+Why this is enough:
+
+- the app needs a homepage because GitHub requires one
+- the homepage does not control PR creation behavior
+- using the repo URL is a simple and acceptable starting point
+
+### Identifying And Authorizing Users
+
+For this workflow:
+
+- do not add a `Callback URL`
+- do not enable `Request user authorization (OAuth) during installation`
+- `Expire user authorization tokens` is not needed for this setup
+
+Why:
+
+- this workflow does not use GitHub OAuth sign-in
+- it does not redirect users back to your app
+- it uses GitHub App installation authentication, not user authorization tokens
+
+### Webhooks
+
+For the first version:
+
+- disable webhook handling
+- do not provide a `Webhook URL`
+- do not provide a `Webhook secret`
+
+Why:
+
+- the workflow is triggered manually through `workflow_dispatch`
+- the app does not need inbound webhook events to open pull requests
+- leaving webhooks out keeps the setup smaller and easier to reason about
+
+### Repository Permissions
+
+Start with:
+
+- `Contents`: `Read and write`
+- `Pull requests`: `Read and write`
+- `Metadata`: read-only is provided by GitHub automatically
+
+Set everything else to `No access` unless implementation proves it is needed later.
+
+Why:
+
+- `Contents` access is needed for repository-level operations tied to the installation
+- `Pull requests` access is needed to create the PR and request reviewers
+- smaller permission scope is safer and easier to audit
+
+### Organization Permissions
+
+If GitHub shows organization permissions and you are not using org-level features:
+
+- leave them as `No access`
+
+Why:
+
+- this workflow only needs repo-scoped PR automation
+- unnecessary org permissions make review harder and increase blast radius
+
+### Installation Scope
+
+When GitHub asks where the app can be installed:
+
+- prefer the smallest scope that still matches your intended usage
+- if you want to reuse the app across multiple repos later, that is fine, but still install it selectively where practical
+
+Why:
+
+- the app can be reusable without being installed everywhere
+- smaller installation scope reduces accidental access
+
 ## Part 2: Get `PR_APP_ID`
 
 1. Open the GitHub App settings page.

--- a/docs/github-app-pr/app-credentials-guide.md
+++ b/docs/github-app-pr/app-credentials-guide.md
@@ -1,0 +1,166 @@
+# How To Get `PR_APP_ID` And `PR_APP_PRIVATE_KEY`
+
+This guide shows how to create or open a GitHub App and get the two values needed by the workflow:
+
+- `PR_APP_ID`
+- `PR_APP_PRIVATE_KEY`
+
+This write-up is meant for general use, not just this repo.
+
+## What These Two Values Are
+
+### `PR_APP_ID`
+
+This is the numeric GitHub App ID.
+
+The workflow uses it together with the private key to mint an installation token for `PR Opener Bot`.
+
+### `PR_APP_PRIVATE_KEY`
+
+This is the full PEM private key generated for the GitHub App.
+
+You store the entire contents of the downloaded private key file as a GitHub Actions secret.
+
+That means you should include:
+
+- `-----BEGIN RSA PRIVATE KEY-----`
+- the full key body
+- `-----END RSA PRIVATE KEY-----`
+
+## Before You Start
+
+Decide these things first:
+
+- Will the app live under your personal GitHub account or an organization?
+- Will the app be reused across multiple repos?
+- Who is allowed to generate, rotate, and revoke private keys?
+
+For a reusable solo developer bot, a personal-account-owned app is often the simplest starting point.
+
+## Part 1: Create Or Open The GitHub App
+
+1. In GitHub, open your profile menu.
+2. Go to `Settings`.
+3. Open `Developer settings`.
+4. Open `GitHub Apps`.
+5. Do one of the following:
+   - If the app does not exist yet, click `New GitHub App`
+   - If the app already exists, click `Edit`
+
+Recommended name:
+
+- `PR Opener Bot`
+
+Recommended purpose:
+
+- `Open pull requests for AI-assisted repo work so the human maintainer can stay in the review and approval path`
+
+## Part 2: Get `PR_APP_ID`
+
+1. Open the GitHub App settings page.
+2. Look for the app metadata near the top of the page.
+3. Copy the numeric `App ID`.
+4. Save that value for later.
+
+Use this value as:
+
+- repository secret: `PR_APP_ID`
+
+## Part 3: Generate `PR_APP_PRIVATE_KEY`
+
+1. Stay on the GitHub App settings page.
+2. Scroll to the `Private keys` section.
+3. Click `Generate a private key`.
+4. GitHub will download a `.pem` file to your computer.
+5. Open the file in a text editor.
+6. Copy the entire file contents exactly as-is.
+
+Use the full PEM contents as:
+
+- repository secret: `PR_APP_PRIVATE_KEY`
+
+Important:
+
+- GitHub only stores the public part of the key
+- if you lose the downloaded private key, you cannot recover it from GitHub
+- if you only have one key and want to rotate safely later, generate a new key before deleting the old one
+
+## Part 4: Store The Values In GitHub Actions
+
+In the target repository:
+
+1. Open `Settings`
+2. Open `Secrets and variables`
+3. Open `Actions`
+4. Add these secrets:
+
+- `PR_APP_ID`
+- `PR_APP_PRIVATE_KEY`
+
+For `PR_APP_PRIVATE_KEY`, paste the entire PEM file content with original line breaks preserved.
+
+## Part 5: Install The App On The Target Repo
+
+The workflow will not work unless the app is installed on the account or repo it needs to access.
+
+After creating the app:
+
+1. Open the app settings
+2. Go to the install section for the app
+3. Install it on the correct personal account or organization
+4. Grant access to the intended repository or repositories
+
+For a smaller blast radius, prefer repo-only access when that matches your use case.
+
+## Common Mistakes
+
+### Secret Contains Only Part Of The Key
+
+Wrong:
+
+- only copying the middle lines
+- removing the `BEGIN` or `END` lines
+
+Right:
+
+- copy the full PEM file content exactly
+
+### App Exists But Is Not Installed
+
+Creating the GitHub App is not enough.
+
+You must also install it on the target account or repo.
+
+### Wrong Secret Type
+
+For this workflow:
+
+- `PR_APP_ID` is stored as a secret in this repo's current implementation
+- `PR_APP_PRIVATE_KEY` is stored as a secret
+
+If you later move `PR_APP_ID` to an Actions variable, update the workflow and docs together.
+
+### Key Was Lost After Download
+
+GitHub does not let you re-download the original private key later.
+
+If the key is lost:
+
+1. Generate a new private key
+2. Update `PR_APP_PRIVATE_KEY`
+3. Delete the old key if it is no longer needed
+
+## Security Guidance
+
+- Never commit the PEM file into the repo
+- Never paste the key into docs, issues, or PR comments
+- Prefer as few private keys as practical
+- Rotate keys when ownership or exposure risk changes
+- Remove old keys after a safe rotation
+
+## Official References
+
+- [Registering a GitHub App](https://docs.github.com/en/apps/creating-github-apps/creating-github-apps/creating-a-github-app)
+- [Managing private keys for GitHub Apps](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps)
+- [Making authenticated API requests with a GitHub App in a GitHub Actions workflow](https://docs.github.com/en/apps/creating-github-apps/guides/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow)
+- [Authenticating as a GitHub App installation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation)

--- a/docs/github-app-pr/operator-guide.md
+++ b/docs/github-app-pr/operator-guide.md
@@ -107,10 +107,14 @@ Use a short body that helps the reviewer decide quickly:
 
 1. Open the repository on GitHub.
 2. Go to the `Actions` tab.
-3. Open the PR creation workflow.
+3. Open the `Create PR via GitHub App` workflow.
 4. Select `Run workflow`.
 5. Fill in `branch`, `base`, `title`, `body`, and `draft`.
 6. Start the run.
+
+Workflow file:
+
+- `.github/workflows/create-pr-via-app.yml`
 
 ## What Success Looks Like
 

--- a/docs/github-app-pr/operator-guide.md
+++ b/docs/github-app-pr/operator-guide.md
@@ -1,0 +1,219 @@
+# GitHub App PR Operator Guide
+
+This guide is for the human operator who wants to open a pull request through the `PR Opener Bot` workflow after Codex has already prepared a branch.
+
+## Why This Flow Exists
+
+This flow is designed for an AI-assisted solo developer workflow.
+
+The pain point is simple:
+
+- AI can help produce the code
+- the human still needs to review and merge responsibly
+- if the human personal account opens the PR directly, that same identity cannot meaningfully serve as the approval path
+
+`PR Opener Bot` solves that by taking the PR opener role, while the human account stays in the reviewer and approver role.
+
+## Workflow Diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Codex
+    participant H as Human Maintainer
+    participant A as GitHub Actions
+    participant B as PR Opener Bot
+    participant R as GitHub Repo
+    participant P as Pull Request
+
+    C->>R: Push branch with AI-assisted changes
+    Note over C,R: Code is ready on a feature branch
+
+    H->>A: Manually trigger PR creation workflow
+    Note over H,A: Human decides when a PR should be opened
+
+    A->>R: Validate branch and workflow inputs
+    A->>B: Request GitHub App installation token
+    B-->>A: Return installation token
+
+    A->>R: Create PR as PR Opener Bot
+    R-->>P: Open new pull request
+
+    A->>P: Request review from Human Maintainer
+
+    H->>P: Review changes
+    H->>P: Approve PR
+    H->>P: Merge PR
+
+    Note over B,H: PR opener identity is separated from reviewer identity
+```
+
+## Before You Start
+
+Make sure:
+
+- the branch has already been pushed to GitHub
+- the workflow and secrets have already been set up
+- the PR title and body are ready
+- you know whether the PR should open as draft or ready for review
+
+## Expected Flow
+
+1. Codex works locally and commits as `Codex <codex@openai.com>`.
+2. The branch is pushed to GitHub.
+3. A human opens the GitHub Actions workflow manually.
+4. The workflow creates the PR through `PR Opener Bot`.
+5. The workflow requests review from `teohsinyee`.
+6. `teohsinyee` reviews and decides whether to merge.
+
+## Inputs You Need
+
+Prepare these values before triggering the workflow:
+
+- `branch`: the source branch to open the PR from
+- `base`: the target branch, usually `main`
+- `title`: the PR title
+- `body`: the PR description
+- `draft`: whether the PR should start as draft
+
+## Recommended Title Style
+
+Use a title that clearly states the change scope.
+
+Examples:
+
+- `docs: add GitHub App PR setup runbook`
+- `ci: add manual PR creation workflow via GitHub App`
+- `docs: document GitHub App PR operator flow`
+
+## Recommended Body Structure
+
+Use a short body that helps the reviewer decide quickly:
+
+```md
+## Summary
+- what changed
+- why it changed
+
+## Validation
+- what was tested
+- what still needs manual verification
+
+## Notes
+- any setup dependencies or reviewer context
+```
+
+## How To Trigger The Workflow
+
+1. Open the repository on GitHub.
+2. Go to the `Actions` tab.
+3. Open the PR creation workflow.
+4. Select `Run workflow`.
+5. Fill in `branch`, `base`, `title`, `body`, and `draft`.
+6. Start the run.
+
+## What Success Looks Like
+
+The run is successful when:
+
+- the workflow finishes without error
+- a pull request is created from the intended branch
+- the PR opener is `PR Opener Bot`, not the reviewer personal identity
+- review is requested from `teohsinyee`
+
+## What To Check On The PR
+
+After creation, verify:
+
+- the head branch is correct
+- the base branch is correct
+- the title is correct
+- the body rendered as expected
+- the PR is draft or ready, as intended
+- `teohsinyee` appears in requested reviewers
+
+## Common Failure Cases
+
+### Branch Not Found
+
+Possible causes:
+
+- the branch was not pushed
+- the branch name was typed incorrectly
+- the workflow is validating against remote branches and the push has not completed
+
+What to do:
+
+- confirm the exact branch name
+- confirm the branch exists on GitHub
+- rerun the workflow with the correct branch
+
+### Missing Or Broken Secrets
+
+Possible causes:
+
+- `PR_APP_ID` is missing
+- `PR_APP_PRIVATE_KEY` is missing
+- the private key formatting is broken
+
+What to do:
+
+- verify the repository secrets exist
+- re-paste the private key with correct line breaks
+- rerun after saving
+
+### App Installed On The Wrong Scope
+
+Possible causes:
+
+- the App is installed on a different repo
+- the installation owner is wrong
+- the workflow is using the wrong installation
+
+What to do:
+
+- review the GitHub App installation page
+- confirm this repo is included
+- confirm the workflow is targeting the intended installation
+
+### Duplicate PR
+
+Possible causes:
+
+- a PR for the branch is already open
+- the workflow was rerun without checking the existing PR list
+
+What to do:
+
+- search open PRs for the same branch
+- reuse the existing PR if it is still the correct one
+- close the old PR first only if that is the intended workflow
+
+### Review Request Not Added
+
+Possible causes:
+
+- the PR was created but reviewer request failed
+- the App permissions are incomplete
+- the request payload is wrong
+
+What to do:
+
+- open the workflow logs
+- confirm whether PR creation succeeded first
+- add the review request manually if needed
+- record the failure in the change logs file for follow-up
+
+## Operator Rules
+
+- Do not use this workflow as a general repo write path
+- Keep the workflow manually triggered by a human
+- Keep human review required before merge
+- Prefer clear titles and bodies so review stays lightweight
+- Record surprising failures so the next run is easier
+
+## After Each Real Run
+
+- check the final PR state
+- note any mismatch between planned and real behavior
+- update `docs/changes/2026-06-06-github-app-pr-automation.logs.md` when something worth keeping happens

--- a/docs/github-app-pr/setup-checklist.md
+++ b/docs/github-app-pr/setup-checklist.md
@@ -94,6 +94,8 @@ Secret handling checks:
 The workflow should:
 
 - [ ] use `workflow_dispatch`
+- [ ] live at `.github/workflows/create-pr-via-app.yml`
+- [ ] appear in GitHub Actions as `Create PR via GitHub App`
 - [ ] accept `branch`, `base`, `title`, `body`, and `draft`
 - [ ] generate a GitHub App installation token
 - [ ] validate branch existence before PR creation

--- a/docs/github-app-pr/setup-checklist.md
+++ b/docs/github-app-pr/setup-checklist.md
@@ -1,0 +1,134 @@
+# GitHub App PR Setup Checklist
+
+This checklist is for the first-time setup of `PR Opener Bot`, a reusable GitHub App for opening pull requests across repos.
+
+## Outcome
+
+After finishing this checklist:
+
+- the repo can use `PR Opener Bot` for PR creation
+- GitHub Actions can mint an installation token for that App
+- a human can manually trigger PR creation
+- review is still routed to `teohsinyee`
+
+## Why This Exists
+
+This setup solves a solo developer workflow problem:
+
+- AI can help write the code
+- the human still needs a clean review and merge path
+- if the same personal account opens the PR, that same person cannot cleanly act as the approver
+
+`PR Opener Bot` creates a separate PR opener identity so the human account can stay in the reviewer or approver role.
+
+## 1. Confirm The Repo Target
+
+- [ ] Confirm the target repository name
+- [ ] Confirm the default branch name
+- [ ] Confirm `teohsinyee` is the intended reviewer account
+- [ ] Confirm the human operator will trigger PR creation manually from Actions
+
+## 2. Create The GitHub App
+
+Create a new GitHub App and keep the scope intentionally narrow.
+
+- [ ] Set the app name to `PR Opener Bot`
+- [ ] Set the owner to the correct GitHub account or organization
+- [ ] Set a homepage URL that points to this repository or a repo doc
+- [ ] Disable any webhook setup unless implementation later requires it
+
+Suggested app purpose:
+
+`Open pull requests for AI-assisted repo work so the human maintainer can stay in the review and approval path`
+
+## 3. Configure GitHub App Permissions
+
+Start with the minimum practical permissions:
+
+- [ ] `Contents: Read and write`
+- [ ] `Pull requests: Read and write`
+- [ ] `Metadata: Read`
+
+Do not add more permissions unless implementation proves they are required.
+
+If review request APIs fail during implementation:
+
+- [ ] Record the exact failing API call
+- [ ] Confirm whether the failure is permission-related or request-shape-related
+- [ ] Add only the smallest extra permission needed
+- [ ] Record the reason in `docs/changes/2026-06-06-github-app-pr-automation.logs.md`
+
+## 4. Generate Credentials
+
+- [ ] Copy the GitHub App ID
+- [ ] Generate a private key
+- [ ] Store the private key in a secure temporary local location
+- [ ] Confirm who is allowed to manage or rotate this key
+
+## 5. Install The App On The Repo
+
+- [ ] Install the App on this repository only, if possible
+- [ ] Confirm the installation includes the correct repo
+- [ ] Confirm the installation owner is correct
+- [ ] Capture the installation ID if the workflow implementation chooses to use it explicitly
+
+## 6. Add GitHub Actions Secrets
+
+In repository secrets, add:
+
+- [ ] `PR_APP_ID`
+- [ ] `PR_APP_PRIVATE_KEY`
+
+Optional only if implementation needs it:
+
+- [ ] `PR_APP_INSTALLATION_ID`
+
+Secret handling checks:
+
+- [ ] The private key is pasted with original line breaks preserved
+- [ ] No extra quote wrapping is added unless the workflow expects it
+- [ ] Secret names match the workflow exactly
+
+## 7. Add Or Update The Workflow
+
+The workflow should:
+
+- [ ] use `workflow_dispatch`
+- [ ] accept `branch`, `base`, `title`, `body`, and `draft`
+- [ ] generate a GitHub App installation token
+- [ ] validate branch existence before PR creation
+- [ ] create the PR through the App identity
+- [ ] request review from `teohsinyee`
+- [ ] fail clearly on duplicate PRs or bad inputs
+
+Recommended operator-facing messages:
+
+- [ ] missing secret error is explicit
+- [ ] branch-not-found error is explicit
+- [ ] duplicate-PR error is explicit
+- [ ] review-request failure is explicit
+
+## 8. Run Validation In Order
+
+- [ ] Validate App authentication in GitHub Actions
+- [ ] Validate token creation
+- [ ] Validate draft PR creation from a test branch
+- [ ] Validate reviewer request to `teohsinyee`
+- [ ] Validate that `teohsinyee` can still approve and merge normally
+
+## 9. Record Evidence
+
+- [ ] Save final workflow behavior notes in the change logs file
+- [ ] Record any permission surprises
+- [ ] Record any API endpoint quirks
+- [ ] Update the operator guide if the real workflow differs from the planned flow
+
+## 10. Ready For Routine Use
+
+This setup is ready for routine use only when all of the following are true:
+
+- [ ] PR creation runs under the GitHub App identity
+- [ ] The workflow is manually triggered by a human
+- [ ] Human review remains required
+- [ ] Failure cases are understandable without reading workflow source code
+- [ ] The repo docs are clear enough for reuse later

--- a/docs/github-app-pr/setup-checklist.md
+++ b/docs/github-app-pr/setup-checklist.md
@@ -65,6 +65,10 @@ If review request APIs fail during implementation:
 - [ ] Store the private key in a secure temporary local location
 - [ ] Confirm who is allowed to manage or rotate this key
 
+Detailed guide:
+
+- [ ] Follow [app-credentials-guide.md](./app-credentials-guide.md) to capture `PR_APP_ID` and `PR_APP_PRIVATE_KEY`
+
 ## 5. Install The App On The Repo
 
 - [ ] Install the App on this repository only, if possible


### PR DESCRIPTION
## Summary
- add structured PR Opener Bot planning and operator docs
- add a manual GitHub App workflow to create pull requests and request review
- add a public-facing guide for getting `PR_APP_ID` and `PR_APP_PRIVATE_KEY`

## Validation
- ran `actionlint` against `.github/workflows/create-pr-via-app.yml`
- confirmed local workflow file and docs changes are committed on this branch
- live GitHub Actions validation still pending because this workflow must first land on the default branch

## Notes
- this is a bootstrap PR so the `Create PR via GitHub App` workflow can be merged into `main`
- after merge, the workflow can be used for future PR creation via the GitHub App
- the temporary local planning file `GITHUB_APP_PR_PLAN.md` was intentionally left out of this PR
